### PR TITLE
docs(cs-03): clarify qesRequest field semantics for transaction_data

### DIFF
--- a/conformance-specs/cs-03-remote-signing-with-wallet-units.md
+++ b/conformance-specs/cs-03-remote-signing-with-wallet-units.md
@@ -232,6 +232,9 @@ The `transaction_data` array MUST contain the following object, base64url-encode
   ]
 }
 ```
+> **NOTE_CSRS_03** In this profile, the base64url-decoded `transaction_data` value is the CSC `qesRequest` object with `type` `https://cloudsignatureconsortium.org/2025/qes`.
+> The `credential_ids` values refer to the `id` of the associated DCQL credential query, and not to CSC API `credentialID` values.
+> For interoperability with Wallet Units that validate `transaction_data` strictly, Relying Parties should not include additional profile-specific members unless this specification defines them.
 
 ## 8.2 Presentation Endpoint
 


### PR DESCRIPTION
This is a small clarification-only change in CS-03, related to https://github.com/webuild-consortium/wp4-interop-test-bed/issues/24.

It adds a note under the `transaction_data` example to make explicit that:
- the decoded object is the CSC `qesRequest` object with type `https://cloudsignatureconsortium.org/2025/qes`
- `credential_ids` refer to the associated DCQL credential query `id`
- Relying Parties should avoid adding extra undefined members, to reduce interoperability issues with strict Wallet Unit validation

No normative flow is changed.