### PR TITLE
Replace did:web with did:webvh in CS02 specification

### DIFF
--- a/conformance-specs/cs-02-credential-presentation.md
+++ b/conformance-specs/cs-02-credential-presentation.md
@@ -87,7 +87,7 @@ The WE BUILD presentation profile is based on OpenID4VP with the following manda
 
 * JWT-Secured Authorisation Request (JAR): All authorisation requests MUST be signed.
 * Digital Credentials Query Language (DCQL): MUST be used for querying credentials.
-* Client Identifier Schemes: Usage of `x509_san_dns` or `verifier_attestation`, `decentralized_identifiers` is also recommended (`did:web`, `did:jwk`)
+* Client Identifier Schemes: Usage of `x509_san_dns` or `verifier_attestation`, `decentralized_identifiers` is also recommended (`did:webvh`, `did:jwk`)
 * Crypto Suites: Strict adherence to P-256 (secp256r1) with ES256 for signing.
 * Holder Binding: Mandatory Key Binding JWT (KB-JWT) for SD-JWT VCs. (See **NOTE_CS02_01**)
 


### PR DESCRIPTION
## Summary

This PR updates the CS02 (Credential Presentation) specification to recommend `did:webvh` instead of `did:web` as a decentralized identifier method.

## Motivation

The `did:web` method has several fundamental limitations that make it unsuitable for high-assurance credential presentation scenarios. The `did:webvh` (Web with Verifiable History) method addresses these concerns.

### Key Differences

| Aspect | did:web | did:webvh |
|--------|---------|-----------|
| **Verifiable History** | No history - only current state | Complete cryptographically verifiable history of all DID Document changes |
| **Key Rotation Security** | Vulnerable to key compromise after rotation | Past signatures remain verifiable even after key rotation |
| **Temporal Verification** | Cannot verify past states | Can verify DID state at any point in time |
| **Domain Hijacking** | Compromised if domain is hijacked | Historical proofs survive domain changes |
| **Repudiation** | Controller can silently modify/remove keys | All changes are logged and verifiable |
| **Trust Model** | Full trust in domain operator | Cryptographic proof of all operations |

### Security Improvements

1. **Cryptographic History Log**: `did:webvh` maintains a hash-chained log (similar to Certificate Transparency) of all DID Document modifications, making unauthorized changes detectable.

2. **Pre-rotation Keys**: Supports declaring future key hashes before they are needed, preventing key substitution attacks.

3. **Witness Network**: Optional witnesses can independently verify and attest to DID Document state changes.

4. **Temporal Proofs**: Verifiers can request proof of the DID state at the exact time a credential was issued, preventing backdated forgeries.

### HAIP Alignment

While HAIP ID-1 mentions `did:web` as one of the recommended decentralized identifier methods, `did:webvh` is a strict superset that maintains web-based resolution while adding essential security guarantees for high-assurance scenarios required by WE BUILD.

## Changes

- Updated Section 5 (Protocol Overview) to recommend `did:webvh` instead of `did:web` in the Client Identifier Schemes

## References

- [did:webvh Specification](https://identity.foundation/didwebvh/v0.5/)
- [did:web Security Considerations](https://w3c-ccg.github.io/did-method-web/#security-and-privacy-considerations)
- [DIF Trust Registries](https://identity.foundation/trust-establishment/)