### PR TITLE
cs-02: clarify Wallet Unit definition and add reciprocal-duty pointers in 7.2

### DIFF
--- a/conformance-specs/cs-02-credential-presentation.md
+++ b/conformance-specs/cs-02-credential-presentation.md
@@ -1,6 +1,15 @@
 # WE BUILD - Conformance Specification:  Credential Presentation
 
-Version 1.0
+Version 1.1 / Approved
+Date: 30 April 2026
+
+**Authors / Contributors**: WP4 Architecture
+
+* Lal Chandran, iGrant.io, Sweden
+* Sander Dijkhuis, Cleverbase, Netherlands
+* George J Padayatti, iGrant.io, Sweden
+* Nikolas Triantafyllou, University of Aegean, Greece
+* Malin Norlander, Bolagsverket, Sweden
 
 Table Of Contents
 

--- a/conformance-specs/cs-02-credential-presentation.md
+++ b/conformance-specs/cs-02-credential-presentation.md
@@ -84,6 +84,8 @@ The terms MUST, MUST NOT, SHOULD, SHOULD NOT, REQUIRED, RECOMMENDED, MAY and OPT
 
 # 4. Roles and Components
 
+The role names defined in this specification (Wallet Unit, Holder, Verifier) are **OpenID4VP protocol roles**, not organisational or product roles. A single software product may implement more than one role at different times, and any given role may be fulfilled by software that also performs other functions (for example, a Business Wallet implementing both Holder and Verifier roles in different interactions). The requirements in this specification attach to the role, not to the product or organisation that implements it.
+
 This specification uses the following roles:
 
 * **Wallet Unit (WU):** A software component on the Holder's device acting on behalf of the Holder to obtain, store and present Verifiable Credentials.
@@ -236,6 +238,7 @@ Verifier processes the Presentation and returns the outcome as in 6.1.7.
 
 # 7. Normative Requirements
 
+The requirements in 7.1 and 7.2 attach to the OpenID4VP **roles** of Wallet Unit and Verifier respectively, as defined in chapter 4, not to the products or organisations implementing them. A relying party deploying a multi-role software product (for example a Business Wallet) to implement the Verifier role is a normal and supported pattern; the obligations in 7.2 apply to the Verifier role inside that product.
 
 ## 7.1 Wallet Unit Requirements
 
@@ -259,24 +262,28 @@ Wallets MUST NOT:
 
 ## 7.2 Verifier Requirements
 
-Verifier obligations are listed below. Each item is an action performed by the Verifier (Relying Party); the wallet's reciprocal duty for the same protocol step is referenced in parentheses.
+Verifier obligations are listed below in two groups: per-transaction protocol behaviours, and deployment-time obligations. All items are normative MUSTs. The wallet's reciprocal duty for the same protocol step is referenced in parentheses.
 
-Verifiers MUST:
+**Verifiers MUST ensure, on every transaction, that:**
 
-1. Create a signed Presentation Request Object. (Wallet reciprocal: 7.1.4)
-2. Use nonces and audience restrictions. (Wallet reciprocal: 7.1.8)
-3. Support same‑device and cross‑device invocation. (Wallet reciprocal: 7.1.2, 7.1.3)
-4. Publish Verifier Metadata.
-5. Provide a Presentation Response Endpoint. (Wallet reciprocal: 7.1.9)
-6. Validate all Presentation Responses, including:
+1. The Presentation Request Object is sealed (signed) by the Verifier. (Wallet reciprocal: 7.1.4)
+2. Nonces and audience restrictions are generated and included. (Wallet reciprocal: 7.1.8)
+6. All Presentation Responses are validated, including:
     * Signature of Presentation Proof
     * Credential authenticity
+    * Wallet Unit Attestation validity (per HAIP)
     * SD‑JWT‑VC disclosure integrity
     * Holder binding
     * Nonce and audience binding
     * Satisfaction of request constraints
 
    (Wallet reciprocal: 7.1.5 to 7.1.8)
+
+**Verifiers MUST, at deployment:**
+
+3. Support same‑device and cross‑device invocation. (Wallet reciprocal: 7.1.2, 7.1.3)
+4. Publish Verifier Metadata.
+5. Provide a Presentation Response Endpoint. (Wallet reciprocal: 7.1.9)
 
 Verifiers MUST NOT:
 

--- a/conformance-specs/cs-02-credential-presentation.md
+++ b/conformance-specs/cs-02-credential-presentation.md
@@ -33,7 +33,7 @@ Table Of Contents
 - [8. Interface Definitions](#8-interface-definitions)
   - [8.1 Wallet Invocation Interface](#81-wallet-invocation-interface)
   - [8.2 Presentation Request Object Interface](#82-presentation-request-object-interface)
-  - [8.3 Presentation Endpoint](#83-presentation-endpoint)
+  - [8.3 Presentation Response Endpoint](#83-presentation-response-endpoint)
   - [8.4 Verifier Metadata Interface](#84-verifier-metadata-interface)
 - [9. Conformance](#9-conformance)
 - [References](#references)
@@ -173,7 +173,7 @@ Upon consent, the Wallet MUST generate:
 
 ### 6.1.6 Presentation Submission
 
-The Wallet MUST POST the Presentation Response to the Verifier’s Presentation Endpoint, including:
+The Wallet MUST POST the Presentation Response to the Verifier’s Presentation Response Endpoint, including:
 
 * `vp_token` containing the JWT‑encoded Presentation
 * format specifying SD‑JWT‑VC
@@ -218,7 +218,7 @@ Same as 6.1.5.
 
 ### 6.2.6 Presentation Submission
 
-WU delivers the Presentation directly to the Verifier’s Presentation Endpoint (back channel). Redirection flow MAY be used if supported.
+WU delivers the Presentation directly to the Verifier’s Presentation Response Endpoint (back channel). Redirection flow MAY be used if supported.
 
 ### 6.2.7 Result Handling
 
@@ -240,7 +240,7 @@ Wallets MUST:
 6. Provide transparent Holder consent.
 7. Generate JWT‑based Presentation Proof.
 8. Bind Presentation Proof to Verifier’s nonce and audience.
-9. Submit Presentation Responses to the Presentation Endpoint.
+9. Submit Presentation Responses to the Presentation Response Endpoint.
 
 Wallets MUST NOT:
 
@@ -258,7 +258,7 @@ Verifiers MUST:
 2. Use nonces and audience restrictions. (Wallet reciprocal: 7.1.8)
 3. Support same‑device and cross‑device invocation. (Wallet reciprocal: 7.1.2, 7.1.3)
 4. Publish Verifier Metadata.
-5. Provide a Presentation Endpoint. (Wallet reciprocal: 7.1.9)
+5. Provide a Presentation Response Endpoint. (Wallet reciprocal: 7.1.9)
 6. Validate all Presentation Responses, including:
     * Signature of Presentation Proof
     * Credential authenticity
@@ -311,7 +311,7 @@ The Presentation Request Object MUST include:
 Wallet Units reject incomplete or invalid request objects.
 
 
-## 8.3 Presentation Endpoint
+## 8.3 Presentation Response Endpoint
 
 Direction: Wallet → Verifier \
 Method: POST \
@@ -362,7 +362,7 @@ An implementation **conforms to this specification as an Issuer** if it:
 
 1. Implements all Verifier requirements in Section 7.2
 2. Publishes required Verifier Metadata
-3. Implements the Presentation Request and Presentation Endpoint interfaces
+3. Implements the Presentation Request and Presentation Response Endpoint interfaces
 4. Supports both same‑device and cross‑device flows
 
 # References

--- a/conformance-specs/cs-02-credential-presentation.md
+++ b/conformance-specs/cs-02-credential-presentation.md
@@ -8,7 +8,7 @@ Date: 30 April 2026
 * Lal Chandran, iGrant.io, Sweden
 * Sander Dijkhuis, Cleverbase, Netherlands
 * George J Padayatti, iGrant.io, Sweden
-* Nikolas Triantafyllou, University of Aegean, Greece
+* Nikolaos Triantafyllou, University of Aegean, Greece
 * Malin Norlander, Bolagsverket, Sweden
 
 Table Of Contents

--- a/conformance-specs/cs-02-credential-presentation.md
+++ b/conformance-specs/cs-02-credential-presentation.md
@@ -77,7 +77,9 @@ The terms MUST, MUST NOT, SHOULD, SHOULD NOT, REQUIRED, RECOMMENDED, MAY and OPT
 
 This specification uses the following roles:
 
-* **Wallet Unit (WU):** A client application or component acting on behalf of the Holder to obtain and store Verifiable Credentials.
+* **Wallet Unit (WU):** A software component on the Holder's device acting on behalf of the Holder to obtain, store and present Verifiable Credentials.
+
+> **NOTE_CSCP_OAUTH_CLIENT** In OpenID4VP terminology, the OAuth Client role is played by the Verifier (Relying Party), not by the Wallet Unit. References to `client_id` in this specification refer to the Verifier.
 * **Holder:** The subject or representative of the subject who controls the Wallet Unit.
 * **Verifier:** Entity requesting verifiable presentations, validating responses and making authorisation decisions.
 
@@ -248,13 +250,15 @@ Wallets MUST NOT:
 
 ## 7.2 Verifier Requirements
 
+Verifier obligations are listed below. Each item is an action performed by the Verifier (Relying Party); the wallet's reciprocal duty for the same protocol step is referenced in parentheses.
+
 Verifiers MUST:
 
-1. Create a signed Presentation Request Object.
-2. Use nonces and audience restrictions.
-3. Support same‑device and cross‑device invocation.
+1. Create a signed Presentation Request Object. (Wallet reciprocal: 7.1.4)
+2. Use nonces and audience restrictions. (Wallet reciprocal: 7.1.8)
+3. Support same‑device and cross‑device invocation. (Wallet reciprocal: 7.1.2, 7.1.3)
 4. Publish Verifier Metadata.
-5. Provide a Presentation Endpoint.
+5. Provide a Presentation Endpoint. (Wallet reciprocal: 7.1.9)
 6. Validate all Presentation Responses, including:
     * Signature of Presentation Proof
     * Credential authenticity
@@ -262,6 +266,8 @@ Verifiers MUST:
     * Holder binding
     * Nonce and audience binding
     * Satisfaction of request constraints
+
+   (Wallet reciprocal: 7.1.5 to 7.1.8)
 
 Verifiers MUST NOT:
 


### PR DESCRIPTION
Closes #194.

Editorial clarifications to CS-02 (Credential Presentation), raised during external review of chapter 7. No normative behaviour is changed (the existing protocol-level MUSTs remain MUSTs); the changes are layout, framing and one missing sub-bullet under item 6.

## Changes

1. Chapter 4 Wallet Unit definition: replace "client application or component" with "software component on the Holder's device", since "client" in OpenID4VP is the OAuth Client role and is played by the Verifier, not the wallet. Short note (NOTE_CSCP_OAUTH_CLIENT) added clarifying the role mapping.
2. Chapter 4 role-vs-component framing: add a paragraph stating that the role names in this CS are OpenID4VP protocol roles, not organisational or product roles, so a single product (including a Business Wallet) may implement more than one role.
3. Chapter 7 preamble: short paragraph reiterating the role-vs-product point and stating explicitly that a relying party deploying a multi-role product to implement the Verifier role is a normal and supported pattern.
4. Chapter 7.2 restructure: split into two groups, both still normative MUSTs:
   - Per-transaction protocol behaviours (items 1, 2, 6, prefixed "Verifiers MUST ensure, on every transaction, that").
   - Deployment-time obligations (items 3, 4, 5, prefixed "Verifiers MUST, at deployment").
   - "Wallet Unit Attestation validity (per HAIP)" added as a new sub-bullet under item 6 to make HAIP's wallet attestation check explicit.
   - Numbering preserved across groups so existing references stay valid.
5. Chapter 7.2 also gains the "(Wallet reciprocal: 7.1.x)" pointers next to each item.
6. Rename "Presentation Endpoint" to "Presentation Response Endpoint" throughout (TOC, 6.1.6, 6.2.6, 7.1.9, 7.2.5, 8.3 heading, chapter 9). Removes the misreading that the Verifier "presents" anything; the endpoint is where the Verifier receives the wallet's presentation response.
7. Header metadata: bumped to Version 1.1 / Approved, dated 30 April 2026, with updated Authors and Contributors block.

## Out of scope (rejected with reasoning)

- Aligning the Wallet Unit definition with the BWR EBW-unit definition: rejected. CS-02 has zero references to EBW today and is intentionally protocol-level. Tying it to a specific deployment regulation would force every future reader to understand BWR even if they implement against a non-EBW wallet. Architecture-layer documents can reference CS-02 for protocol behaviour and add EBW-specific definitions on top.
- Adding a "validate state of wallet" requirement: addressed in scope, by adding "Wallet Unit Attestation validity (per HAIP)" as a sub-bullet under item 6, which is the protocol-level expression of wallet-state validation that HAIP already mandates. Anything beyond that (revocation registry policy, governance status checks) belongs in the trust-framework profile, not in CS-02.
- Adding a "present RP access certificate to holder" requirement: rejected. Verifier identity disclosure to the user is a UX and trust-framework obligation driven by EUDI ARF / EBW Trust Framework, not an OpenID4VP wire-conformance obligation. CS-02 stays neutral on the trust framework so it can be reused under different regimes.
- Merging 7.1 and 7.2: rejected. The split is intentional, mirrored in chapter 9 conformance, and was added in an earlier review round to make Wallet and Verifier obligations independently certifiable.