### PR TITLE
cs-02: Fix reference as per OpenID4VP

### DIFF
--- a/conformance-specs/cs-02-credential-presentation.md
+++ b/conformance-specs/cs-02-credential-presentation.md
@@ -383,7 +383,7 @@ An implementation **conforms to this specification as an Issuer** if it:
 
 # References
 
-[1]	OpenID Foundation (2025). OpenID for Verifiable Credential Issuance 1.0. OpenID Foundation, 16 September. Available at: [https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html) (Accessed: 24 November 2025).
+[1]	OpenID Foundation (2025). OpenID for Verifiable Presentations 1.0. OpenID Foundation, 9 July. Available at: [https://openid.net/specs/openid-4-verifiable-presentations-1_0.html](https://openid.net/specs/openid-4-verifiable-presentations-1_0.html) (Accessed: 24 November 2025).
 
 [2]	OpenID Foundation (2025) OpenID4VC High Assurance Interoperability Profile – draft 03. OpenID Foundation. Available at: [https://openid.net/specs/openid4vc-high-assurance-interoperability-profile-1_0-ID1.html](https://openid.net/specs/openid4vc-high-assurance-interoperability-profile-1_0-ID1.html)  (Accessed: 24 November 2025)
 


### PR DESCRIPTION
Closes #202.

- Reference [1]: replace the OpenID for Verifiable Credential Issuance citation with the correct OpenID for Verifiable Presentations citation (title and URL).